### PR TITLE
Changed lifecycle policy creation

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -80,50 +80,20 @@ resource "aws_ecr_repository_policy" "this" {
               : data.aws_iam_policy_document.ecs_ecr_read_perms.json}"
 }
 
-# aws_ecr_lifecycle_policy_rule is used as template for a rule of the lifecycle policy
-locals {
-  aws_ecr_lifecycle_policy_rule = {
-    rulePriority = "$${priority}"
-    description  = "Rotate images after amount of: $${max_image_count} is reached for prefix $${prefix}"
+# Interpolate the rule_priority with the count.index + 1
+# The idea was to use template_vars but they do not render, hence the replace
+data "template_file" "lifecycle_policy_rules" {
+  count = "${(var.create ? 1 : 0 ) * var.lifecycle_policy_rules_count}"
 
-    selection = {
-      tagStatus     = "tagged"
-      tagPrefixList = ["$${prefix}"]
-      countType     = "imageCountMoreThan"
-      countNumber   = "$${max_image_count}"
-    }
-
-    action = {
-      type = "expire"
-    }
-  }
-}
-
-# Create a policy rule per stage
-# The jsonencoded aws_ecr_lifecycle_policy_rule will be used as template, the variables will be replaced
-# A policy will be made per available prefix
-data "template_file" "lifecycle_policy" {
-  count = "${(var.create ? 1 : 0 ) * length(var.prefixes)}"
-
-  template = "${jsonencode(local.aws_ecr_lifecycle_policy_rule)}"
-
-  vars {
-    priority = "${count.index + 1}"
-    prefix   = "${var.prefixes[count.index]}"
-
-    # If there is no count defined in the map var.prefixes_pecific_max_count, we take the var.default_max_image_count
-    max_image_count = "${lookup(var.prefixes_specific_max_count,var.prefixes[count.index], var.default_max_image_count)}"
-  }
+  template = "${replace( var.lifecycle_policy_rules[count.index], "priority:replace:this",( count.index + 1) )}"
 }
 
 # The final rendered lifecycle_policy will be regexed to remove the double quotes surrounding strings
 resource "aws_ecr_lifecycle_policy" "this" {
-  count      = "${var.create ? 1 : 0 }"
+  count      = "${var.create && var.lifecycle_policy_rules_count > 0 ? 1 : 0 }"
   repository = "${aws_ecr_repository.this.name}"
 
-  policy = "${replace(
-               replace("{\"rules\": [${join(",",data.template_file.lifecycle_policy.*.rendered)}]}",
+  policy = "${replace("{\"rules\": [${join(",",data.template_file.lifecycle_policy_rules.*.rendered)}]}",
 		 "/\"(true|false|[[:digit:]]+)\"/", "$1"
-	), "string:", ""
-      )}"
+	)}"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -2,6 +2,11 @@ variable "namespace" {
   description = "The namespace we interpolate in all resources"
 }
 
+variable "create" {
+  description = "create defines if resources need to be created true/false"
+  default     = true
+}
+
 variable "use_namespaces" {
   description = "use_namespaces defines if we want to interpolate the namespace inside the repo name"
   default     = true
@@ -10,28 +15,6 @@ variable "use_namespaces" {
 # The name of the ECR repository
 variable "name" {
   description = "name defines the name of the repository, by default it will be interpolated to {namespace}-{name}"
-}
-
-variable "default_max_image_count" {
-  description = "default_max_image_count defines the default maximum image count after which images needs to rotate"
-  default     = "100"
-}
-
-# prefixes_pecific_max_count defines the map of stages when the default_max_image_count is not
-# the right setting
-# example
-# { 
-#  dev = 40
-#  prod = 100
-# }
-variable "prefixes_specific_max_count" {
-  description = "prefixes_specific_max_count defines the map of stages when the default_max_image_count is not the preferred count for a specific prefix"
-  default     = {}
-}
-
-variable "create" {
-  description = "create defines if resources need to be created true/false"
-  default     = true
 }
 
 variable "allowed_read_principals" {
@@ -45,7 +28,12 @@ variable "allowed_write_principals" {
   default     = []
 }
 
-variable "prefixes" {
-  description = "prefixes define which prefixes need to have lifecycle rules applied"
+variable "lifecycle_policy_rules_count" {
+  description = "The amount of lifecycle_policy_rules, this to make sure we are not running into computed count problems"
+  default     = "0"
+}
+
+variable "lifecycle_policy_rules" {
+  description = "List of json lifecycle policy rules, created by another module: doingcloudright/ecr-lifecycle-policy-rule/aws"
   default     = []
 }


### PR DESCRIPTION
## What

Change lifecycle policy creation, moved the creation of lifecycle policy rules to a different module.

## Why

To make it possible to create different policies, tagged, untagged, or any and make sure that the order of the policies can be determined.