### PR TITLE
Add an output for the ECR repo's ARN

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -1,6 +1,6 @@
-output "arn" {
+output "repository_arn" {
   value       = "${element(concat(aws_ecr_repository.this.*.arn, list("")), 0)}"
-  description = "Registry ARN"
+  description = "Repository ARN"
 }
 
 output "registry_id" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -10,7 +10,7 @@ output "registry_id" {
 
 output "repository_name" {
   value       = "${element(concat(aws_ecr_repository.this.*.name, list("")), 0)}"
-  description = "Registry name"
+  description = "Repository name"
 }
 
 output "registry_url" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,3 +1,8 @@
+output "arn" {
+  value       = "${element(concat(aws_ecr_repository.this.*.arn, list("")), 0)}"
+  description = "Registry ARN"
+}
+
 output "registry_id" {
   value       = "${element(concat(aws_ecr_repository.this.*.registry_id, list("")), 0)}"
   description = "Registry id"

--- a/outputs.tf
+++ b/outputs.tf
@@ -5,7 +5,7 @@ output "repository_arn" {
 
 output "registry_id" {
   value       = "${element(concat(aws_ecr_repository.this.*.registry_id, list("")), 0)}"
-  description = "Registry id"
+  description = "Registry ID"
 }
 
 output "repository_name" {
@@ -15,5 +15,5 @@ output "repository_name" {
 
 output "registry_url" {
   value       = "${element(concat(aws_ecr_repository.this.*.repository_url, list("")), 0)}"
-  description = "Registry url"
+  description = "Registry URL"
 }


### PR DESCRIPTION
Hello! 

I would have a use for this module outputting the ARN of the repositories it creates, but the feature is lacking. It seems both trivial and harmless to add it, so here's a PR!

Question: I reproduced your pattern with `value = "${element(concat(aws_ecr_repository.this.*.arn, list("")), 0)}"` but don't understand what it does vs. simply `value = "${aws_ecr_repository.this.arn}"`?