### PR TITLE
Suppress TF 0.12.14+ language deprecation warnings

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -1,19 +1,19 @@
 output "repository_arn" {
-  value       = "${element(concat(aws_ecr_repository.this.*.arn, list("")), 0)}"
+  value       = element(concat(aws_ecr_repository.this.*.arn, list("")), 0)
   description = "Repository ARN"
 }
 
 output "repository_name" {
-  value       = "${element(concat(aws_ecr_repository.this.*.name, list("")), 0)}"
+  value       = element(concat(aws_ecr_repository.this.*.name, list("")), 0)
   description = "Repository name"
 }
 
 output "registry_id" {
-  value       = "${element(concat(aws_ecr_repository.this.*.registry_id, list("")), 0)}"
+  value       = element(concat(aws_ecr_repository.this.*.registry_id, list("")), 0)
   description = "Registry ID"
 }
 
 output "registry_url" {
-  value       = "${element(concat(aws_ecr_repository.this.*.repository_url, list("")), 0)}"
+  value       = element(concat(aws_ecr_repository.this.*.repository_url, list("")), 0)
   description = "Registry URL"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -19,12 +19,12 @@ variable "name" {
 
 variable "allowed_read_principals" {
   description = "allowed_read_principals defines which external principals are allowed to read from the ECR repository"
-  type        = "list"
+  type        = list
 }
 
 variable "allowed_write_principals" {
   description = "allowed_write_principals defines which external principals are allowed to write to the ECR repository"
-  type        = "list"
+  type        = list
   default     = []
 }
 


### PR DESCRIPTION
Hi there,

As you may know, Terraform 0.12.14 [introduced](https://github.com/hashicorp/terraform/blob/master/CHANGELOG.md#01214-november-13-2019) a change that generates warnings when using Terraform 0.11 syntax.

The code in this module generates warnings that look like this:

```
Warning: Quoted type constraints are deprecated

  on .terraform/modules/ecr_awscli_repo_watcher/variables.tf line 22, in variable "allowed_read_principals":
  22:   type        = "list"

Terraform 0.11 and earlier required type constraints to be given in quotes,
but that form is now deprecated and will be removed in a future version of
Terraform. To silence this warning, remove the quotes around "list" and write
list(string) instead to explicitly indicate that the list elements are
strings.
```

You updated most but not all of your code to conform to the new 0.12 standards, so this PR aims to hammer out the remaining instances of old syntax in your code and get rid of these annoying warnings 😄 